### PR TITLE
Fix for Zig master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  x86_64-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+      - name: build
+        run: zig build

--- a/build.zig
+++ b/build.zig
@@ -17,8 +17,7 @@ pub fn build(b: *std.Build) void {
         .root_module = module,
         .linkage = .static,
     });
-    lib.installHeadersDirectory(b.path("wayland"), "wayland", .{});
-    lib.installHeadersDirectory(b.path("wayland-protocols"), "wayland-protocols", .{});
-    lib.installHeadersDirectory(b.path("libdecor"), "libdecor", .{});
+    lib.installHeadersDirectory(b.path("wayland"), ".", .{});
+    lib.installHeadersDirectory(b.path("wayland-protocols"), ".", .{});
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,3 +1,24 @@
 const std = @import("std");
 
-pub fn build(_: *std.Build) void {}
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
+    module.addCSourceFile(.{
+        .file = b.addWriteFiles().add("empty.c", ""),
+    });
+
+    const lib = b.addLibrary(.{
+        .name = "wayland-headers",
+        .root_module = module,
+        .linkage = .static,
+    });
+    lib.installHeadersDirectory(b.path("wayland"), "wayland", .{});
+    lib.installHeadersDirectory(b.path("wayland-protocols"), "wayland-protocols", .{});
+    lib.installHeadersDirectory(b.path("libdecor"), "libdecor", .{});
+    b.installArtifact(lib);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .wayland_headers,
     .version = "1.23.90",
     .fingerprint = 0xf2f733e969c040cc,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0-dev.1393+493265486",
 
     .paths = .{
         "libdecor",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,7 @@
         "libdecor",
         "wayland",
         "wayland-protocols",
+        "build.zig",
         "build.zig.zon",
         "update.sh",
         "verify.sh",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .wayland_headers,
     .version = "1.23.90",
     .fingerprint = 0xf2f733e969c040cc,
-    .minimum_zig_version = "0.15.0-dev.1393+493265486",
+    .minimum_zig_version = "0.15.0-dev.1425+7ee6dab39",
 
     .paths = .{
         "libdecor",


### PR DESCRIPTION
I added build script behaviour so the one in falsepattern/glfw can use the headers by linking to the exposed library (implemented in the PR mentioned below).

I've opened PRs doing the same stuff to the other dependencies of zig-glfw (x11-headers, vulkan-headers).
As soon as these PRs are accepted I will update the build.zig.zon dependency reference to the new commit and open a PR under falsepattern/glfw (and after that one in falsepattern/zig-glfw).

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.